### PR TITLE
Pull key stats feature

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
 from scrapy.crawler import CrawlerProcess
+import spider
 import os
 
 filename = input("Please enter a filename for the spider output:> ")
@@ -13,7 +14,8 @@ process = CrawlerProcess(settings={
     "FEEDS": {
         filename: {"format": "json"},
     },
+    "LOG_ENABLED": False,
 })
 
-process.crawl(cnnMarket)
+process.crawl(spider.cnnMarket)
 process.start()

--- a/spider.py
+++ b/spider.py
@@ -7,9 +7,24 @@ class cnnMarket(scrapy.Spider):
     ]
 
     def parse(self,response):
-        for item in response.css("a.ticker"):
-            yield {
-                "Name": item.css('span.ticker-name::text').get(),
-                "Points": item.css('span.ticker-points::text').get(),
-                "Change": item.css('span.ticker-name-change span.posData::text').get(),
-            }
+        if response.url == self.start_urls[0]:
+            for item in response.css("a.ticker"):
+                yield {
+                    "Name": item.css('span.ticker-name::text').get(),
+                    "Points": item.css('span.ticker-points::text').get(),
+                    "Change": item.css('span.ticker-name-change span.posData::text').get(),
+                }
+        else:
+            for item in response.css("tr"):
+                ticker = item.css("td.wsod_firstCol span::text").get()
+                if ticker is not None:
+                    yield {
+                        "name":ticker,
+                        "price_data":item.css("td.wsod_aRight span::text").getall(),
+                    }    
+        
+        next_page = response.css("a.module-header::attr(href)").getall()
+        
+        for item in next_page:
+            new_page = response.urljoin(item)
+            yield scrapy.Request(new_page,callback=self.parse)


### PR DESCRIPTION
This request contains a fix for an import error with the `run` script, it now included the spider module. A search is now made across all available links for each page and follows them to search for tabular data. Currently the DOW JONES individual stocks it indexes is returned with a list containing price data. 

A QOL fix was made to remove the excess log information from scrapy to the console, so now it only outputs the user prompts.