### PR TITLE
Major overhaul to stdout and argument parsing for v0.2.0-a3

### DIFF
--- a/Tools.py
+++ b/Tools.py
@@ -1,0 +1,30 @@
+"""
+A module for webdriver interactions.
+"""
+from selenium import webdriver
+import requests
+
+import sys
+
+def isFailedResponse(url: str) -> bool:
+    """
+    Check url for response code 404: page not found.
+    """
+    try:
+        return requests.get(url).status_code == 404
+    except:
+        return True
+
+def getTableElements(driver: webdriver.Chrome,tableIndex: int = 0) -> [webdriver.WebKitGTK._web_element_cls,...]:
+    """
+    Find a table with chrome webdriver.
+
+    Returns a list of table row elements.
+    """
+    try:
+        selector = driver.find_elements_by_css_selector("table.wsod_dataTableBig")
+        table = selector[tableIndex].find_element_by_tag_name('tbody')
+        return table.find_elements_by_tag_name('tr')
+    except Exception as e:
+        sys.stdout.write(e)
+        return None

--- a/app.py
+++ b/app.py
@@ -5,8 +5,6 @@ class Stock:
     def __init__(self,client: webdriver.Chrome,**kwargs):
         self._configuration = kwargs
         self._client = client
-        
-        self.getPage()
     
     def Start(self):
         self._client.get("https://money.cnn.com/data/markets/")

--- a/app.py
+++ b/app.py
@@ -10,12 +10,10 @@ class Stock:
         self._configuration = kwargs
         self._client = client
     
-    def Start(self):
-        self._client.get("https://money.cnn.com/data/markets/")
-    
     def getOverview(self):
         overview_data = {}
-
+        self._client.get("https://money.cnn.com/data/markets/")
+    
         overview_items = self._client.find_element_by_class_name("markets-overview")
         tickers = overview_items.find_elements_by_css_selector("a.ticker")
         
@@ -73,17 +71,17 @@ class Stock:
                         response[item][row[0]] = row[1:]
                 except Exception as e:
                     pass
-        else:
+        elif isinstance(markets,str):
             self._client.get(url + f"/markets/{markets}/")
-            
+
             try:
                 table_items = getTableElements(self._client,2)
                 for table_item in table_items:
                     row = table_item.get_attribute('innerText').split()
                     response[item][row[0]] = row[1:]
             except Exception as e:
-                print(e)
-
+                pass
+ 
         if keystats:
             self._client.get(url + "/dow30/")
             dow30_items = getTableElements(self._client)

--- a/app.py
+++ b/app.py
@@ -37,5 +37,8 @@ class Stock:
 
         return DOW_composite_data
 
+    def getUpdated(self):
+        pass
+
     def Close(self):
         self._client.quit()

--- a/app.py
+++ b/app.py
@@ -1,4 +1,8 @@
 from selenium import webdriver
+from Tools import (
+    isFailedResponse,
+    getTableElements,
+)
 
 class Stock:
 
@@ -24,19 +28,75 @@ class Stock:
         
         return overview_data
 
-    def getTable(self):
+    def getTable(self,keystats: bool = False,markets: list = None) -> dict:
+        """
+        Get a table specified from the markets endpoint and whether to include keystats table. 
+        """
+        url = "https://money.cnn.com/data"
+
+        response = {}
         DOW_composite_data ={}
-        self._client.get("https://money.cnn.com/data/dow30/")
-        dow30_table = self._client.find_element_by_css_selector('table.wsod_dataTableBig')
-        dow30_items = dow30_table.find_elements_by_tag_name('tr')
+        markets_data = {}
 
-        for item in dow30_items:
-            name = item.find_element_by_class_name('wsod_firstCol').get_attribute('innerText').split('\xa0')[0]
-            data = [txt.text for txt in item.find_elements_by_class_name("wsod_aRight")]
-            DOW_composite_data[name] = data
+        if not(markets is None):
+            try:
+                for item in markets:
+                    if not isinstance(item,str):
+                        raise TypeError(f"'{item}' in argument 'markets' expected '{type(str)}', received '{type(item)}'.")
+            except:
+                if not isinstance(markets,str):
+                    raise TypeError(f"'{markets}' in argument 'markets' expected '{type(str)}', received '{type(markets)}'.")
 
-        return DOW_composite_data
+        if isinstance(markets,list):
+            for item in markets:
+                if isFailedResponse(url + f"/markets/{item}/"):
+                    return {"Error":f"'{item}' in argument 'markets' not found."}
+                
+                # make a new dictionary
+                response[item] = {}
 
+                self._client.get(url + f"/markets/{item}/")
+
+                try:
+                    table_items = getTableElements(self._client,2)
+                    for table_item in table_items:
+                        row = table_item.get_attribute('innerText').split()
+                        response[item][row[0]] = row[1:]
+                except Exception as e:
+                    pass
+                    
+                try:
+                    self._client.find_element_by_id("fwd").click()
+                    table_items = getTableElements(self._client,2)
+                    for table_item in table_items:
+                        row = thing.get_attribute('innerText').split()
+                        response[item][row[0]] = row[1:]
+                except Exception as e:
+                    pass
+        else:
+            self._client.get(url + f"/markets/{markets}/")
+            
+            try:
+                table_items = getTableElements(self._client,2)
+                for table_item in table_items:
+                    row = table_item.get_attribute('innerText').split()
+                    response[item][row[0]] = row[1:]
+            except Exception as e:
+                print(e)
+
+        if keystats:
+            self._client.get(url + "/dow30/")
+            dow30_items = getTableElements(self._client)
+
+            for item in dow30_items:
+                name = item.find_element_by_class_name('wsod_firstCol').get_attribute('innerText').split('\xa0')[0]
+                data = [txt.text for txt in item.find_elements_by_class_name("wsod_aRight")]
+                DOW_composite_data[name] = data
+
+            response["keystats"] = DOW_composite_data
+        
+        return response
+    
     def getUpdated(self):
         self._client.get("https://money.cnn.com/data/markets/")
         response = self._client.find_element_by_css_selector("div.disclaimer").get_attribute('innerText')

--- a/app.py
+++ b/app.py
@@ -40,10 +40,10 @@ class Stock:
             try:
                 for item in markets:
                     if not isinstance(item,str):
-                        raise TypeError(f"'{item}' in argument 'markets' expected '{type(str)}', received '{type(item)}'.")
+                        raise TypeError(f"'{item}' in argument 'markets' expected '{str}', received '{type(item)}'.")
             except:
                 if not isinstance(markets,str):
-                    raise TypeError(f"'{markets}' in argument 'markets' expected '{type(str)}', received '{type(markets)}'.")
+                    raise TypeError(f"'{markets}' in argument 'markets' expected '{str}', received '{type(markets)}'.")
 
         if isinstance(markets,list):
             for item in markets:

--- a/app.py
+++ b/app.py
@@ -38,7 +38,9 @@ class Stock:
         return DOW_composite_data
 
     def getUpdated(self):
-        pass
+        self._client.get("https://money.cnn.com/data/markets/")
+        response = self._client.find_element_by_css_selector("div.disclaimer").get_attribute('innerText')
+        return response
 
     def Close(self):
         self._client.quit()

--- a/app.py
+++ b/app.py
@@ -26,8 +26,8 @@ class Stock:
 
     def getTable(self):
         DOW_composite_data ={}
-        driver.get("https://money.cnn.com/data/dow30/")
-        dow30_table = driver.find_element_by_css_selector('table.wsod_dataTableBig')
+        self._client.get("https://money.cnn.com/data/dow30/")
+        dow30_table = self._client.find_element_by_css_selector('table.wsod_dataTableBig')
         dow30_items = dow30_table.find_elements_by_tag_name('tr')
 
         for item in dow30_items:
@@ -37,5 +37,5 @@ class Stock:
 
         return DOW_composite_data
 
-    def Close():
+    def Close(self):
         self._client.close()

--- a/app.py
+++ b/app.py
@@ -1,0 +1,43 @@
+from selenium import webdriver
+
+class Stock:
+
+    def __init__(self,client: webdriver.Chrome,**kwargs):
+        self._configuration = kwargs
+        self._client = client
+        
+        self.getPage()
+    
+    def Start(self):
+        self._client.get("https://money.cnn.com/data/markets/")
+    
+    def getOverview(self):
+        overview_data = {}
+
+        overview_items = self._client.find_element_by_class_name("markets-overview")
+        tickers = overview_items.find_elements_by_css_selector("a.ticker")
+        
+        for item in tickers:
+            name=item.find_element_by_class_name("ticker-name").get_attribute('innerText')
+            percent=item.find_element_by_class_name("ticker-name-change").text
+            pts=item.find_element_by_class_name("ticker-points").text
+            pts_change=item.find_element_by_class_name("ticker-points-change").text
+            overview_data[name] = [pts,percent,pts_change]
+        
+        return overview_data
+
+    def getTable(self):
+        DOW_composite_data ={}
+        driver.get("https://money.cnn.com/data/dow30/")
+        dow30_table = driver.find_element_by_css_selector('table.wsod_dataTableBig')
+        dow30_items = dow30_table.find_elements_by_tag_name('tr')
+
+        for item in dow30_items:
+            name = item.find_element_by_class_name('wsod_firstCol').get_attribute('innerText').split('\xa0')[0]
+            data = [txt.text for txt in item.find_elements_by_class_name("wsod_aRight")]
+            DOW_composite_data[name] = data
+
+        return DOW_composite_data
+
+    def Close():
+        self._client.close()

--- a/app.py
+++ b/app.py
@@ -38,4 +38,4 @@ class Stock:
         return DOW_composite_data
 
     def Close(self):
-        self._client.close()
+        self._client.quit()

--- a/money.py
+++ b/money.py
@@ -38,7 +38,7 @@ data = {}
 if args.overview:
     data["overview"] = app.getOverview()
 
-data["tables"] = app.getTable(args.keystats)
+data["tables"] = app.getTable(args.keystats,args.usindex)
 
 data["last-updated"] = app.getUpdated()
 

--- a/money.py
+++ b/money.py
@@ -1,6 +1,7 @@
 import os
 import json
 
+from app import Stock
 from utils.Parser import Parse
 
 args = Parse()
@@ -24,35 +25,20 @@ chrome_options.add_argument("log-level=3")
 chrome_options.add_experimental_option("prefs",{"profile.default_content_settings.cookies": 2})
 driver = webdriver.Chrome(executable_path="{}/chromedriver.exe".format(DRIVER),options=chrome_options)
 
-# Visit and retreive info from page
-overview_data = {}
-driver.get("https://money.cnn.com/data/markets/")
-overview_items = driver.find_element_by_class_name("markets-overview")
-tickers = overview_items.find_elements_by_css_selector("a.ticker")
+# Get stock info by default
+app = Stock(driver)
 
-for item in tickers:
-    name=item.find_element_by_class_name("ticker-name").get_attribute('innerText')
-    percent=item.find_element_by_class_name("ticker-name-change").text
-    pts=item.find_element_by_class_name("ticker-points").text
-    pts_change=item.find_element_by_class_name("ticker-points-change").text
-    overview_data[name] = [pts,percent,pts_change]
-
-DOW_composite_data ={}
-driver.get("https://money.cnn.com/data/dow30/")
-dow30_table = driver.find_element_by_css_selector('table.wsod_dataTableBig')
-dow30_items = dow30_table.find_elements_by_tag_name('tr')
-
-for item in dow30_items:
-    name = item.find_element_by_class_name('wsod_firstCol').get_attribute('innerText').split('\xa0')[0]
-    data = [txt.text for txt in item.find_elements_by_class_name("wsod_aRight")]
-    DOW_composite_data[name] = data
-
-driver.close()
+app.Start()
+overview_data = app.getOverview()
+DOW_composite_data = app.getTable()
+app.Close()
 
 cwd = os.getcwd()
 
 with open(cwd + "/data/market_overview.json",'w') as file:
-    json.dump(overview_data,file)  
+    json.dump(overview_data,file) 
+
+print(overview_data)
 with open(cwd + "/data/DOW30.json",'w') as file:
     json.dump(DOW_composite_data,file)
 

--- a/money.py
+++ b/money.py
@@ -4,10 +4,10 @@ import json
 from app import Stock
 from utils.Parser import Parse
 
-args = Parse()
-
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+
+args = Parse()
 
 try:
     DRIVER = os.environ['SELENIUM_CHROME']
@@ -35,10 +35,11 @@ app.Close()
 
 cwd = os.getcwd()
 
-with open(cwd + "/data/market_overview.json",'w') as file:
-    json.dump(overview_data,file) 
+if args.suppress:
+    with open(cwd + "/data/market_overview.json",'w') as file:
+        json.dump(overview_data,file) 
 
-print(overview_data)
-with open(cwd + "/data/DOW30.json",'w') as file:
-    json.dump(DOW_composite_data,file)
-
+    with open(cwd + "/data/DOW30.json",'w') as file:
+        json.dump(DOW_composite_data,file)
+else:
+    print(f"{overview_data}\n{DOW_composite_data}")

--- a/money.py
+++ b/money.py
@@ -1,9 +1,11 @@
 import os
+import sys
 import json
 
 from app import Stock
 from utils.Parser import Parse
 
+from multiprocessing import Queue
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
@@ -36,10 +38,13 @@ app.Close()
 cwd = os.getcwd()
 
 if args.suppress:
+    if not(os.path.exists("data")):
+        os.makedirs('data')
+    
     with open(cwd + "/data/market_overview.json",'w') as file:
         json.dump(overview_data,file) 
 
     with open(cwd + "/data/DOW30.json",'w') as file:
         json.dump(DOW_composite_data,file)
 else:
-    print(f"{overview_data}\n{DOW_composite_data}")
+    sys.stdout.write(f"{overview_data}\n{DOW_composite_data}")

--- a/money.py
+++ b/money.py
@@ -21,7 +21,7 @@ chrome_options = Options()
 chrome_options.add_argument("--headless")
 chrome_options.add_argument("--disable-extensions")
 chrome_options.add_argument("--disable-gpu")
-chrome_options.add_argument("log-level=3")
+chrome_options.add_experimental_option('excludeSwitches', ['enable-logging'])
 chrome_options.add_experimental_option("prefs",{"profile.default_content_settings.cookies": 2})
 driver = webdriver.Chrome(executable_path="{}/chromedriver.exe".format(DRIVER),options=chrome_options)
 

--- a/money.py
+++ b/money.py
@@ -28,11 +28,22 @@ chrome_options.add_experimental_option("prefs",{"profile.default_content_setting
 driver = webdriver.Chrome(executable_path="{}/chromedriver.exe".format(DRIVER),options=chrome_options)
 
 # Get stock info by default
-app = Stock(driver)
+if args.app == 'stock':
+    app = Stock(driver)
+else:
+    raise NotImplementedError(f"Application '{args.app}' not currently implemented in this version.")
 
 app.Start()
-overview_data = app.getOverview()
-DOW_composite_data = app.getTable()
+
+data = {}
+
+if args.overview:
+    data["overview"] = app.getOverview()
+if args.keystats:
+    data["dow30"] = app.getTable()
+
+data["last-updated"] = app.getUpdated()
+
 app.Close()
 
 cwd = os.getcwd()
@@ -40,11 +51,9 @@ cwd = os.getcwd()
 if args.suppress:
     if not(os.path.exists("data")):
         os.makedirs('data')
-    
-    with open(cwd + "/data/market_overview.json",'w') as file:
-        json.dump(overview_data,file) 
 
-    with open(cwd + "/data/DOW30.json",'w') as file:
-        json.dump(DOW_composite_data,file)
+    with open(cwd + f"/data/{args.app}.json",'w') as file:
+        json.dump(data,file) 
+
 else:
-    sys.stdout.write(f"{overview_data}\n{DOW_composite_data}")
+    sys.stdout.write(f"{data}")

--- a/money.py
+++ b/money.py
@@ -33,14 +33,12 @@ if args.app == 'stock':
 else:
     raise NotImplementedError(f"Application '{args.app}' not currently implemented in this version.")
 
-app.Start()
-
 data = {}
 
 if args.overview:
     data["overview"] = app.getOverview()
-if args.keystats:
-    data["dow30"] = app.getTable()
+
+data["tables"] = app.getTable(args.keystats)
 
 data["last-updated"] = app.getUpdated()
 

--- a/money.py
+++ b/money.py
@@ -1,6 +1,10 @@
 import os
 import json
 
+from utils.Parser import Parse
+
+args = Parse()
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
@@ -51,6 +55,4 @@ with open(cwd + "/data/market_overview.json",'w') as file:
     json.dump(overview_data,file)  
 with open(cwd + "/data/DOW30.json",'w') as file:
     json.dump(DOW_composite_data,file)
-n):> ") in ('y','Y',"yes","Yes"):
-        pass
 

--- a/run.py
+++ b/run.py
@@ -2,7 +2,6 @@ import os
 import json
 
 from selenium import webdriver
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import Options
 
 try:
@@ -52,3 +51,6 @@ with open(cwd + "/data/market_overview.json",'w') as file:
     json.dump(overview_data,file)  
 with open(cwd + "/data/DOW30.json",'w') as file:
     json.dump(DOW_composite_data,file)
+n):> ") in ('y','Y',"yes","Yes"):
+        pass
+

--- a/utils/Parser.py
+++ b/utils/Parser.py
@@ -23,7 +23,8 @@ def Parse(*args):
     overview = stockParser.add_argument('--overview',action="store_true",help='Return market overview data containing top 3 indexes for US.')
     keystats = stockParser.add_argument('--key-stats',dest="keystats",action="store_true",help="Returns top 30 DOW Jones index data.")
     hot = stockParser.add_argument('--hot',action='store_true',help="Returns the hot stocks: Most Active, Gainers, Losers.")
-
+    USindex = stockParser.add_argument('--US-index','--US','-U',dest="usindex",nargs=1,default=None,help="Add a specific US index to output.")
+    
     # Story arguments
     frontpage = storyParser.add_argument('--front-page',dest="frontpage",action='store_true',help="Return the front page news story headliners.")
     investing = storyParser.add_argument('--investing',action='store_true',help="Return the top investing story headliners.")

--- a/utils/Parser.py
+++ b/utils/Parser.py
@@ -1,0 +1,32 @@
+import argparse as ap
+
+def Parse(*args):
+    parser = ap.ArgumentParser(prog="money",description="A toolkit for retrieving CNN Money Market webpage data.")
+
+    # File arguments
+    suppress = parser.add_argument("--suppress","-s",action="store_true",help="Write data as file to /<program_directory>/data/*.json")
+
+    # Data arguments
+    app = parser.add_argument("app",default=["stock"],nargs='*',help="Return story/stock/currency data from webpages (Default is stock).")
+    img = parser.add_argument("--image","-i",dest='img',action="store_true",help="Return image data from speficied app.")
+
+    # Format arguments
+    _format = parser.add_argument("--format",'-f',nargs=1,default='json',help="Write data to stdout or a file in specified format (Default is json). See docs for valid types.")
+
+    collection = ap.Namespace()  
+    if not(args is None):
+        collection = parser.parse_args(*args)
+    else:
+        collection = parser.parse_args()
+    
+    if len(collection.app) > 3:
+        raise ap.ArgumentError(app,f"Too many applications listed. {len(collection.app)} found, expected at most 3.")
+    for application_listed in collection.app:
+        if not(application_listed in {'story', 'stock', 'currency'}):
+            raise ap.ArgumentError(app,f"'{application_listed}' not a valid application process."+
+                "\nCheck documentation or type 'money -h' for help.")
+    
+    if not(collection.format in {'txt','json','table'}):
+        raise ap.ArgumentError(_format,f"'{collection.format}' not a valid stdout format. Expected 'txt','json' or 'table'.")
+
+    return collection

--- a/utils/Parser.py
+++ b/utils/Parser.py
@@ -4,14 +4,14 @@ def Parse(*args):
     parser = ap.ArgumentParser(prog="money",description="A toolkit for retrieving CNN Money Market webpage data.")
 
     # File arguments
-    suppress = parser.add_argument("--suppress","-s",action="store_true",help="Write data as file to /<program_directory>/data/*.json")
+    suppress = parser.add_argument("-s","--suppress",action="store_true",help="Suppress stdout. Write data as file to /<program_directory>/data/*.<format> (Default format is json).")
 
     # Data arguments
     app = parser.add_argument("app",default=["stock"],nargs='*',help="Return story/stock/currency data from webpages (Default is stock).")
-    img = parser.add_argument("--image","-i",dest='img',action="store_true",help="Return image data from speficied app.")
+    img = parser.add_argument("-i","--image",dest='img',action="store_true",help="Return image data from speficied app.")
 
     # Format arguments
-    _format = parser.add_argument("--format",'-f',nargs=1,default='json',help="Write data to stdout or a file in specified format (Default is json). See docs for valid types.")
+    _format = parser.add_argument('-f',"--format",nargs=1,default='json',help="Write data to stdout or a file in specified format (Default is json). See docs for valid types.")
 
     collection = ap.Namespace()  
     if not(args is None):

--- a/utils/Parser.py
+++ b/utils/Parser.py
@@ -1,32 +1,44 @@
 import argparse as ap
 
 def Parse(*args):
+    # Top parser
     parser = ap.ArgumentParser(prog="money",description="A toolkit for retrieving CNN Money Market webpage data.")
-
+    
+    # Application parsers
+    subParser = parser.add_subparsers(dest='app',help="Application to be executed.")
+    storyParser = subParser.add_parser('story',help="The money markets story application.",description="Retrieve story data from Money Markets webpage.")  
+    stockParser = subParser.add_parser('stock',help="The money makets stock application.",description="This application retrieves stock data.")
+    currencyParser = subParser.add_parser('money',help="The money markets currency application.",description="This application returns currency information for a specified denomination. The default behavior is to print out the valuation of top 7 currencies listed on the page.")
+    
     # File arguments
     suppress = parser.add_argument("-s","--suppress",action="store_true",help="Suppress stdout. Write data as file to /<program_directory>/data/*.<format> (Default format is json).")
 
     # Data arguments
-    app = parser.add_argument("app",default=["stock"],nargs='*',help="Return story/stock/currency data from webpages (Default is stock).")
     img = parser.add_argument("-i","--image",dest='img',action="store_true",help="Return image data from speficied app.")
 
     # Format arguments
-    _format = parser.add_argument('-f',"--format",nargs=1,default='json',help="Write data to stdout or a file in specified format (Default is json). See docs for valid types.")
+    _format = parser.add_argument('-f',"--format",nargs=1,default=['json'],help="Write data to stdout or a file in specified format (Default is json). See docs for valid types.")
 
+    # Stock arguments
+    overview = stockParser.add_argument('--overview',action="store_true",help='Return market overview data containing top 3 indexes for US.')
+    keystats = stockParser.add_argument('--key-stats',dest="keystats",action="store_true",help="Returns top 30 DOW Jones index data.")
+    hot = stockParser.add_argument('--hot',action='store_true',help="Returns the hot stocks: Most Active, Gainers, Losers.")
+
+    # Story arguments
+    frontpage = storyParser.add_argument('--front-page',dest="frontpage",action='store_true',help="Return the front page news story headliners.")
+    investing = storyParser.add_argument('--investing',action='store_true',help="Return the top investing story headliners.")
+    expanded = storyParser.add_argument('-e',dest='indices',nargs=2,help="Expand each story within start and end index and return the full article.")
+    
     collection = ap.Namespace()  
     if not(args is None):
         collection = parser.parse_args(*args)
     else:
         collection = parser.parse_args()
     
-    if len(collection.app) > 3:
-        raise ap.ArgumentError(app,f"Too many applications listed. {len(collection.app)} found, expected at most 3.")
-    for application_listed in collection.app:
-        if not(application_listed in {'story', 'stock', 'currency'}):
-            raise ap.ArgumentError(app,f"'{application_listed}' not a valid application process."+
-                "\nCheck documentation or type 'money -h' for help.")
-    
-    if not(collection.format in {'txt','json','table'}):
+    if not(collection.format[0] in {'txt','json','table'}):
         raise ap.ArgumentError(_format,f"'{collection.format}' not a valid stdout format. Expected 'txt','json' or 'table'.")
-
+    
+    if collection.app is None:
+        raise ap.ArgumentError(subParser,"Application is required. See 'money -h' for usage.")
+    
     return collection


### PR DESCRIPTION
# Goal

This pull request seeks to overhaul the command line interaction with the user, with only minor changes to the output for default behavior.

## Argument Parsing

There are three subparsers for separating program functionality, now requiring at least one of these three arguments:

* stock

* story (not implemented in this release)

* money (not implemented in this release)

## stock

```bash
usage: money stock [-h] [--overview] [--key-stats] [--hot]
                   [--US-index USINDEX]

This application retrieves stock data.

optional arguments:
  -h, --help            show this help message and exit
  --overview            Return market overview data containing top 3 indexes
                        for US.
  --key-stats           Returns top 30 DOW Jones index data.
  --hot                 Returns the hot stocks: Most Active, Gainers, Losers.
  --US-index USINDEX, --US USINDEX, -U USINDEX
                        Add a specific US index to output.
```

When no flags are present, the default behavior still prints JSON by default similar to [v0.1.1-a3](v0.1.1-a3). The response is now completely written to stdout with no chrome webdriver debug comments. A standard response now contains this:
```
{
    # a collection of all the tables specified
    "tables":{ },
    # string containing date and time of websites last change
    "last-updated":' ',
}
```
With no flags, `tables` will be empty and it will supply the last market update time. To get the data from [v0.1.1-a3](v0.1.1-a3) you will need to call the program this way:
```bash
money stock --overview
```
and see an output like:
```bash
{'overview': {'Dow': ['25,763.16', '0.62%', '157.62'], 'Nasdaq': ['9,726.02', '1.43%', '137.21'], 'S&P': ['3,066.59', '0.83%', '25.28']}, 'tables': {}, 'last-updated': 'Updated: Jun 15 5:18pm ET'}
```
so through the `overview` key you can retrieve the same information from before the update.
